### PR TITLE
add EEG class, PartialDirectedCoherence, and ReciprocalConnecti…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pandas>=3.0.1",
     "scikit-learn>=1.8.0",
     "scipy>=1.17.1",
+    "statsmodels>=0.14",
     "xarray>=2026.2.0",
 ]
 

--- a/src/cobrabox/data.py
+++ b/src/cobrabox/data.py
@@ -684,7 +684,51 @@ class EEG(SignalData):
 
     EEG is a time-series signal data type with mandatory time dimension.
     Typically also includes 'space' dimension representing electrodes/channels.
+
+    Args:
+        ref_channel: The reference used for this recording. One of:
+
+            * ``None``        — reference unspecified (default).
+            * ``'average'``   — common average reference.
+            * ``'bipolar'``   — channels are already bipolar (re-referenced
+              against adjacent electrodes).
+            * any channel name that appears in the ``'space'`` coordinate —
+              single-electrode reference.
+
+    Raises:
+        ValueError: If ``ref_channel`` is not ``None``, ``'average'``,
+            ``'bipolar'``, or a channel present in the ``'space'`` coordinate.
     """
+
+    def __init__(
+        self,
+        data: xr.DataArray,
+        sampling_rate: float | None = None,
+        subjectID: str | None = None,
+        groupID: str | None = None,
+        condition: str | None = None,
+        history: list[str] | None = None,
+        extra: dict[str, Any] | None = None,
+        ref_channel: str | None = None,
+    ) -> None:
+        super().__init__(
+            data=data,
+            sampling_rate=sampling_rate,
+            subjectID=subjectID,
+            groupID=groupID,
+            condition=condition,
+            history=history,
+            extra=extra,
+        )
+        _RESERVED = {"average", "bipolar"}
+        if ref_channel is not None and ref_channel not in _RESERVED:
+            space_coords = list(data.coords["space"].values) if "space" in data.coords else []
+            if ref_channel not in space_coords:
+                raise ValueError(
+                    f"ref_channel {ref_channel!r} must be 'average', "
+                    f"'bipolar', or one of the space coords: {space_coords}."
+                )
+        self.ref_channel: str | None = ref_channel
 
 
 class FMRI(SignalData):

--- a/src/cobrabox/feature.pyi
+++ b/src/cobrabox/feature.pyi
@@ -18,8 +18,10 @@ from .features import MeanAggregate as MeanAggregate
 from .features import Min as Min
 from .features import PartialCorrelation as PartialCorrelation
 from .features import PartialCorrelationMatrix as PartialCorrelationMatrix
+from .features import PartialDirectedCoherence as PartialDirectedCoherence
 from .features import PhaseLockingValue as PhaseLockingValue
 from .features import PhaseLockingValueMatrix as PhaseLockingValueMatrix
+from .features import ReciprocalConnectivity as ReciprocalConnectivity
 from .features import SlidingWindow as SlidingWindow
 from .features import SlidingWindowReduce as SlidingWindowReduce
 from .features import Spectrogram as Spectrogram
@@ -44,8 +46,10 @@ __all__ = [
     "Min",
     "PartialCorrelation",
     "PartialCorrelationMatrix",
+    "PartialDirectedCoherence",
     "PhaseLockingValue",
     "PhaseLockingValueMatrix",
+    "ReciprocalConnectivity",
     "SlidingWindow",
     "SlidingWindowReduce",
     "Spectrogram",

--- a/src/cobrabox/features/__init__.pyi
+++ b/src/cobrabox/features/__init__.pyi
@@ -18,8 +18,10 @@ from .mean_aggregate import MeanAggregate as MeanAggregate
 from .min import Min as Min
 from .partial_correlation import PartialCorrelation as PartialCorrelation
 from .partial_correlation import PartialCorrelationMatrix as PartialCorrelationMatrix
+from .partial_directed_coherence import PartialDirectedCoherence as PartialDirectedCoherence
 from .phase_locking_value import PhaseLockingValue as PhaseLockingValue
 from .phase_locking_value import PhaseLockingValueMatrix as PhaseLockingValueMatrix
+from .reciprocal_connectivity import ReciprocalConnectivity as ReciprocalConnectivity
 from .sliding_window import SlidingWindow as SlidingWindow
 from .sliding_window_reduce import SlidingWindowReduce as SlidingWindowReduce
 from .spectrogram import Spectrogram as Spectrogram
@@ -44,8 +46,10 @@ __all__ = [
     "Min",
     "PartialCorrelation",
     "PartialCorrelationMatrix",
+    "PartialDirectedCoherence",
     "PhaseLockingValue",
     "PhaseLockingValueMatrix",
+    "ReciprocalConnectivity",
     "SlidingWindow",
     "SlidingWindowReduce",
     "Spectrogram",

--- a/src/cobrabox/features/coherence.py
+++ b/src/cobrabox/features/coherence.py
@@ -33,12 +33,12 @@ class Coherence(BaseFeature[SignalData]):
         >>> data = cb.dataset("dummy_random")[0]
         >>> coh = cb.feature.Coherence().apply(data)
         >>> coh.data.dims
-        ('space', 'space_to')
+        ('space_to', 'space_from')
 
     Returns:
-        xarray DataArray with dims ``(*extra_dims, space, space_to)`` (plus a
+        xarray DataArray with dims ``(*extra_dims, space_to, space_from)`` (plus a
         singleton ``time`` dimension added by ``BaseFeature.apply``). Both
-        ``space`` and ``space_to`` carry the original channel coordinates.
+        ``space_to`` and ``space_from`` carry the original channel coordinates.
         Values are in [0, 1]; the diagonal is NaN (self-coherence). The matrix
         is symmetric: ``result[i, j] == result[j, i]``.
     """
@@ -126,6 +126,6 @@ class Coherence(BaseFeature[SignalData]):
         extra_coords = {d: xr_data.coords[d].values for d in extra_dims if d in xr_data.coords}
         return xr.DataArray(
             coh_matrix,
-            dims=(*extra_dims, "space", "space_to"),
-            coords={**extra_coords, "space": space_coords, "space_to": space_coords},
+            dims=(*extra_dims, "space_to", "space_from"),
+            coords={**extra_coords, "space_to": space_coords, "space_from": space_coords},
         )

--- a/src/cobrabox/features/envelope_correlation.py
+++ b/src/cobrabox/features/envelope_correlation.py
@@ -33,7 +33,7 @@ class EnvelopeCorrelation(BaseFeature[SignalData]):
             the mne-connectivity default of ``True``).
 
     Returns:
-        xarray DataArray with dims ``(space, space_to)`` containing
+        xarray DataArray with dims ``(space_to, space_from)`` containing
         Pearson correlation values between amplitude envelopes.
 
     Raises:
@@ -84,9 +84,9 @@ class EnvelopeCorrelation(BaseFeature[SignalData]):
         # get_data() → (n_epochs, n_nodes, n_nodes, n_times); take the single epoch and time
         mat = conn.get_data()[0, :, :, 0]
 
-        da = xr.DataArray(mat, dims=["space", "space_to"])
+        da = xr.DataArray(mat, dims=["space_to", "space_from"])
         coords: dict[str, np.ndarray] = {}
         if space_coords is not None:
-            coords["space"] = space_coords
             coords["space_to"] = space_coords
+            coords["space_from"] = space_coords
         return da.assign_coords(coords)

--- a/src/cobrabox/features/partial_directed_coherence.py
+++ b/src/cobrabox/features/partial_directed_coherence.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import numpy as np
+import xarray as xr
+from statsmodels.tsa.api import VAR
+
+from ..base_feature import BaseFeature
+from ..data import Data, SignalData
+
+
+@dataclass
+class PartialDirectedCoherence(BaseFeature[SignalData]):
+    """Estimate the Partial Directed Coherence (PDC) between channels via a VAR model.
+
+    Fits a multivariate autoregressive (VAR) model to the input time series using
+    :class:`statsmodels.tsa.vector_ar.var_model.VAR`, then derives the PDC spectrum
+    from the estimated coefficient matrices.
+
+    For each frequency bin, ``PDC[i, j, f]`` represents the normalized directional
+    influence **from channel j to channel i**. Values lie in ``[0, 1]`` and sum to 1
+    across the ``space_to`` (sink) dimension for each source channel and frequency bin::
+
+        sum_i PDC[i, j, f]^2 = 1  for all j, f
+
+    Args:
+        var_order: Number of lags for the VAR model. If ``None`` (default), the
+            optimal order is selected automatically using the AIC criterion.
+        n_freqs: Number of frequency bins in ``[0, sr/2]`` (Nyquist). Default 128.
+
+    Returns:
+        xarray DataArray with dims ``("space_to", "space_from", "frequency")``, shape
+        ``(n_channels, n_channels, n_freqs)``. The ``frequency`` coordinate runs
+        from 0 Hz to the Nyquist frequency. Values are real-valued in ``[0, 1]``.
+
+    Raises:
+        ValueError: If ``data.sampling_rate`` is ``None``.
+        ValueError: If the input has fewer than 2 channels.
+        ValueError: If the input is not 2-D (space x time).
+        ValueError: If ``var_order < 1`` or ``n_freqs < 1``.
+
+    Example:
+        >>> pdc = cb.feature.PartialDirectedCoherence().apply(signal_data)
+        >>> pdc.data.dims  # ('space_to', 'space_from', 'frequency')
+        >>> pdc.data.shape  # (n_ch, n_ch, 128)
+    """
+
+    var_order: int | None = None
+    n_freqs: int = 128
+
+    output_type: ClassVar[type[Data]] = Data
+
+    def __post_init__(self) -> None:
+        if self.var_order is not None and self.var_order < 1:
+            raise ValueError(f"var_order must be a positive integer, got {self.var_order}.")
+        if self.n_freqs < 1:
+            raise ValueError(f"n_freqs must be a positive integer, got {self.n_freqs}.")
+
+    def __call__(self, data: SignalData) -> xr.DataArray:  # type: ignore[override]
+        if data.sampling_rate is None:
+            raise ValueError("PartialDirectedCoherence requires data.sampling_rate to be set.")
+
+        xr_data = data.data
+        dims = xr_data.dims
+
+        if xr_data.ndim != 2:
+            raise ValueError(
+                f"PartialDirectedCoherence requires 2-D input (space x time), "
+                f"got shape {xr_data.shape} with dims {dims}."
+            )
+
+        # SignalData always puts time last — shape is (K, T)
+        n_ch, _n_times = xr_data.shape
+
+        if n_ch < 2:
+            raise ValueError(f"PartialDirectedCoherence requires at least 2 channels, got {n_ch}.")
+
+        sr = data.sampling_rate
+        values = xr_data.values  # (K, T)
+
+        # --- Fit VAR model ---
+        # statsmodels VAR expects (T, K)
+        var_model = VAR(values.T)
+        if self.var_order is None:
+            fit = var_model.fit(ic="aic")
+        else:
+            fit = var_model.fit(maxlags=self.var_order)
+
+        coefs = fit.coefs  # (p, K, K): coefs[k, i, j] = A_{k+1}[i, j]
+        p = coefs.shape[0]
+
+        # --- Build A(f) = I - sum_{k=1}^{p} A_k * exp(-2pi*i*k*f/sr) ---
+        freqs = np.linspace(0.0, sr / 2.0, self.n_freqs)  # (n_freqs,)
+
+        # A shape: (n_freqs, K, K)
+        A = np.zeros((self.n_freqs, n_ch, n_ch), dtype=complex)
+        np.einsum("fii->fi", A)[:] = 1.0  # identity diagonal
+
+        for k in range(1, p + 1):
+            phase = np.exp(-2j * np.pi * k * freqs / sr)  # (n_freqs,)
+            # coefs[k-1]: (K, K); phase: (n_freqs,) → broadcast to (n_freqs, K, K)
+            A -= coefs[k - 1][np.newaxis, :, :] * phase[:, np.newaxis, np.newaxis]
+
+        # --- PDC[i, j, f] = |A[f, i, j]| / sqrt(sum_m |A[f, m, j]|^2) ---
+        # Column-normalise over i (space / sink dimension)
+        A_abs = np.abs(A)  # (n_freqs, K, K)
+        col_norm = np.sqrt((A_abs**2).sum(axis=1, keepdims=True))  # (n_freqs, 1, K)
+        # Avoid division by zero (shouldn't happen for non-degenerate VAR)
+        col_norm = np.where(col_norm == 0.0, 1.0, col_norm)
+        pdc = A_abs / col_norm  # (n_freqs, K, K)
+
+        # Reorder to (K, K, n_freqs) → dims (space_to, space_from, frequency)
+        pdc = pdc.transpose(1, 2, 0)  # (K, K, n_freqs)
+
+        # --- Build coordinates ---
+        if "space" in xr_data.coords:
+            space_vals = xr_data.coords["space"].values
+        else:
+            space_vals = np.arange(n_ch)
+
+        return xr.DataArray(
+            pdc,
+            dims=["space_to", "space_from", "frequency"],
+            coords={"space_to": space_vals, "space_from": space_vals, "frequency": freqs},
+        )

--- a/src/cobrabox/features/reciprocal_connectivity.py
+++ b/src/cobrabox/features/reciprocal_connectivity.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+import numpy as np
+import xarray as xr
+
+from ..base_feature import BaseFeature
+from ..data import Data
+
+
+@dataclass
+class ReciprocalConnectivity(BaseFeature[Data]):
+    """Compute per-channel Reciprocal Connectivity (RC) from a directed connectivity measure.
+
+    **Reciprocal Connectivity** quantifies the net directional role of each channel:
+    positive values indicate a net *sink* (more influence received than sent), and
+    negative values indicate a net *source* (more influence sent than received).
+
+    For each channel ``i``::
+
+        RC[i] = in_strength[i] - out_strength[i]
+
+    where (using PDC notation where ``mat[i, j]`` = flow *from j to i*):
+
+    * ``in_strength[i]``  = mean over j of ``mat[i, j, band]``
+    * ``out_strength[i]`` = mean over j of ``mat[j, i, band]``
+
+    **Two usage modes:**
+
+    1. **Time-series input** (``"time"`` dimension present): fits a VAR model and
+       computes PDC internally using :class:`PartialDirectedCoherence`.
+    2. **Pre-computed matrix input** (``"space_to"`` + ``"space_from"`` dimensions, no
+       ``"time"``): uses the provided asymmetric connectivity matrix directly.
+
+    Args:
+        connectivity: Connectivity measure for time-series mode. Currently only
+            ``"pdc"`` is supported. Ignored for pre-computed matrix input.
+        freq_band: Frequency band ``(fmin, fmax)`` in Hz used to average out the
+            frequency dimension. If the matrix has no ``"frequency"`` dimension,
+            set to ``None``. Default ``(30.0, 80.0)`` Hz.
+        var_order: VAR model order for time-series mode. ``None`` selects the
+            order automatically via AIC. Passed to :class:`PartialDirectedCoherence`.
+        n_freqs: Number of frequency bins for internal PDC computation. Default 128.
+        normalize: If ``True``, z-score the connectivity matrix (excluding the
+            diagonal) before computing strengths.
+
+    Returns:
+        xarray DataArray with dim ``("space",)``, shape ``(n_channels,)``, containing
+        the Reciprocal Connectivity score for each channel.
+
+    Raises:
+        ValueError: If time-series input is provided but ``connectivity != "pdc"``.
+        ValueError: If pre-computed matrix is symmetric (directional RC requires
+            asymmetry).
+        ValueError: If ``freq_band`` is set but the matrix has no ``"frequency"``
+            dimension.
+        ValueError: If ``freq_band`` is outside the available frequency range.
+        ValueError: If ``freq_band=None`` but matrix has a ``"frequency"`` dimension.
+
+    Example:
+        >>> # From time-series SignalData
+        >>> rc = cb.feature.ReciprocalConnectivity(freq_band=(30.0, 80.0)).apply(signal_data)
+        >>> rc.data.dims  # ('space',)
+
+        >>> # From pre-computed PDC matrix (no freq dim)
+        >>> rc = cb.feature.ReciprocalConnectivity(freq_band=None).apply(pdc_matrix)
+    """
+
+    connectivity: str = "pdc"
+    freq_band: tuple[float, float] | None = field(default=(30.0, 80.0))
+    var_order: int | None = None
+    n_freqs: int = 128
+    normalize: bool = False
+
+    output_type: ClassVar[type[Data]] = Data
+
+    def __post_init__(self) -> None:
+        if self.freq_band is not None:
+            fmin, fmax = self.freq_band
+            if fmin >= fmax:
+                raise ValueError(f"freq_band must satisfy fmin < fmax, got ({fmin}, {fmax}).")
+
+    def __call__(self, data: Data) -> xr.DataArray:
+        from .partial_directed_coherence import PartialDirectedCoherence
+
+        xr_data = data.data
+        dims = xr_data.dims
+
+        # ------------------------------------------------------------------ #
+        # PATH A — time-series input
+        # ------------------------------------------------------------------ #
+        if "time" in dims:
+            if self.connectivity != "pdc":
+                raise ValueError(
+                    f"Unsupported connectivity measure {self.connectivity!r} for "
+                    f"time-series input. Only 'pdc' is currently supported."
+                )
+            pdc_feat = PartialDirectedCoherence(var_order=self.var_order, n_freqs=self.n_freqs)
+            # Call __call__ directly to get the raw DataArray;
+            # data must have sampling_rate set (checked inside PDC)
+            mat = pdc_feat(data)  # type: ignore[arg-type]
+
+        # ------------------------------------------------------------------ #
+        # PATH B — pre-computed connectivity matrix
+        # ------------------------------------------------------------------ #
+        else:
+            if "space_to" not in dims or "space_from" not in dims:
+                raise ValueError(
+                    "Pre-computed input must have 'space_to' and 'space_from' dimensions. "
+                    f"Got dims: {dims}."
+                )
+            mat = xr_data
+
+            # Symmetry check for 2-D matrices (no frequency dim)
+            if "frequency" not in mat.dims:
+                mat_vals = mat.values
+                if mat_vals.ndim == 2 and np.allclose(mat_vals, mat_vals.T, atol=1e-6):
+                    raise ValueError(
+                        "Pre-computed connectivity matrix appears symmetric. "
+                        "Reciprocal Connectivity requires a directed (asymmetric) matrix."
+                    )
+
+        # ------------------------------------------------------------------ #
+        # Frequency-band averaging
+        # ------------------------------------------------------------------ #
+        if self.freq_band is not None:
+            if "frequency" not in mat.dims:
+                raise ValueError(
+                    f"freq_band={self.freq_band} is set but the connectivity matrix "
+                    "has no 'frequency' dimension. Pass freq_band=None to skip band averaging."
+                )
+            freqs = mat.coords["frequency"].values
+            fmin, fmax = self.freq_band
+            if fmin > freqs.max() or fmax < freqs.min():
+                raise ValueError(
+                    f"freq_band ({fmin}, {fmax}) Hz is outside the available "
+                    f"frequency range [{freqs.min():.4g}, {freqs.max():.4g}] Hz."
+                )
+            mat = mat.sel(frequency=slice(fmin, fmax)).mean("frequency")
+        else:
+            if "frequency" in mat.dims:
+                raise ValueError(
+                    "The connectivity matrix has a 'frequency' dimension but "
+                    "freq_band=None. Set freq_band to (fmin, fmax) to select a band."
+                )
+
+        # mat is now (space_to, space_from) — shape (K, K)
+        mat_vals = mat.values.copy().astype(float)
+        n_ch = mat_vals.shape[0]
+
+        # Optional z-score normalisation (before diagonal masking)
+        if self.normalize:
+            mask = ~np.eye(n_ch, dtype=bool)
+            off_diag = mat_vals[mask]
+            mu, sigma = off_diag.mean(), off_diag.std()
+            if sigma > 0:
+                mat_vals = (mat_vals - mu) / sigma
+
+        # Mask diagonal with NaN so it does not contribute to strength means
+        np.fill_diagonal(mat_vals, np.nan)
+
+        # in_strength[i]  = mean over j of mat[i, j]  (how much flows INTO i)
+        in_strength = np.nanmean(mat_vals, axis=1)  # (K,) — average over space_from
+
+        # out_strength[i] = mean over j of mat[j, i]  (how much flows OUT OF i)
+        out_strength = np.nanmean(mat_vals, axis=0)  # (K,) — average over space_to
+
+        rc = in_strength - out_strength  # (K,)
+
+        if "space_to" in mat.coords:
+            space_vals = mat.coords["space_to"].values
+        else:
+            space_vals = np.arange(n_ch)
+
+        return xr.DataArray(rc, dims=["space"], coords={"space": space_vals})

--- a/tests/test_feature_coherence.py
+++ b/tests/test_feature_coherence.py
@@ -24,20 +24,20 @@ def _make_data(arr: np.ndarray, *, sampling_rate: float = 100.0) -> cb.SignalDat
 
 
 def test_coherence_output_dims_and_shape() -> None:
-    """Coherence returns Data with (space, space_to, time=1) dims and NxN matrix."""
+    """Coherence returns Data with (space, space_from) dims and NxN matrix."""
     rng = np.random.default_rng(0)
     data = _make_data(rng.standard_normal((300, 4)))
 
     out = cb.feature.Coherence().apply(data)
 
     assert isinstance(out, cb.Data)
-    assert out.data.dims == ("space", "space_to")
-    assert out.data.sizes["space"] == 4
+    assert out.data.dims == ("space_to", "space_from")
     assert out.data.sizes["space_to"] == 4
+    assert out.data.sizes["space_from"] == 4
 
 
 def test_coherence_space_coords_are_preserved() -> None:
-    """Both space and space_to carry the original channel coordinates."""
+    """Both space and space_from carry the original channel coordinates."""
     arr_xr = xr.DataArray(
         np.random.default_rng(1).standard_normal((300, 3)),
         dims=["time", "space"],
@@ -47,8 +47,8 @@ def test_coherence_space_coords_are_preserved() -> None:
 
     out = cb.feature.Coherence().apply(data)
 
-    np.testing.assert_array_equal(out.data.coords["space"].values, ["Fz", "Cz", "Pz"])
     np.testing.assert_array_equal(out.data.coords["space_to"].values, ["Fz", "Cz", "Pz"])
+    np.testing.assert_array_equal(out.data.coords["space_from"].values, ["Fz", "Cz", "Pz"])
 
 
 # ---------------------------------------------------------------------------
@@ -163,8 +163,8 @@ def test_coherence_with_run_index_preserves_extra_dim() -> None:
 
     assert "run_index" in out.data.dims
     assert out.data.sizes["run_index"] == n_runs
-    assert out.data.sizes["space"] == n_space
     assert out.data.sizes["space_to"] == n_space
+    assert out.data.sizes["space_from"] == n_space
     # Each run's diagonal must be NaN
     for r in range(n_runs):
         mat = out.data.isel(run_index=r).values

--- a/tests/test_feature_envelope_correlation.py
+++ b/tests/test_feature_envelope_correlation.py
@@ -30,17 +30,17 @@ def _make_data(
 
 
 def test_envelope_correlation_output_dims_and_shape() -> None:
-    """EnvelopeCorrelation returns (space, space_to, time) Data."""
+    """EnvelopeCorrelation returns (space, space_from) Data."""
     data = _make_data()
     out = cb.feature.EnvelopeCorrelation().apply(data)
 
     assert isinstance(out, cb.Data)
-    assert out.data.dims == ("space", "space_to")
+    assert out.data.dims == ("space_to", "space_from")
     assert out.data.shape == (4, 4)
 
 
 def test_envelope_correlation_space_coords_preserved() -> None:
-    """space and space_to carry the original channel coordinates."""
+    """space and space_from carry the original channel coordinates."""
     import xarray as xr
 
     arr_xr = xr.DataArray(
@@ -51,8 +51,8 @@ def test_envelope_correlation_space_coords_preserved() -> None:
     data = cb.data.SignalData.from_xarray(arr_xr)
     out = cb.feature.EnvelopeCorrelation().apply(data)
 
-    np.testing.assert_array_equal(out.data.coords["space"].values, ["Fz", "Cz", "Pz"])
     np.testing.assert_array_equal(out.data.coords["space_to"].values, ["Fz", "Cz", "Pz"])
+    np.testing.assert_array_equal(out.data.coords["space_from"].values, ["Fz", "Cz", "Pz"])
 
 
 # ---------------------------------------------------------------------------
@@ -108,7 +108,7 @@ def test_envelope_correlation_orthogonalize_false_same_shape() -> None:
     out = cb.feature.EnvelopeCorrelation(orthogonalize=False).apply(data)
 
     assert out.data.shape == (4, 4)
-    assert out.data.dims == ("space", "space_to")
+    assert out.data.dims == ("space_to", "space_from")
 
 
 def test_envelope_correlation_orthogonalize_changes_values() -> None:

--- a/tests/test_feature_partial_directed_coherence.py
+++ b/tests/test_feature_partial_directed_coherence.py
@@ -1,0 +1,207 @@
+"""Tests for the PartialDirectedCoherence feature."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import cobrabox as cb
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_data(
+    arr: np.ndarray, *, sampling_rate: float = 250.0, space: list[str] | None = None
+) -> cb.SignalData:
+    """Create SignalData from a (space, time) 2-D NumPy array."""
+    coords: dict = {}
+    if space is not None:
+        coords["space"] = space
+    xr_arr = xr.DataArray(arr, dims=["space", "time"], coords=coords)
+    return cb.SignalData.from_xarray(xr_arr, sampling_rate=sampling_rate)
+
+
+def _coupled_signals(
+    n_times: int, sr: float, drive_freq: float, *, rng: np.random.Generator | None = None
+) -> np.ndarray:
+    """Return (2, n_times) array where channel 0 drives channel 1 at drive_freq Hz."""
+    if rng is None:
+        rng = np.random.default_rng(42)
+    t = np.arange(n_times) / sr
+    driver = np.sin(2 * np.pi * drive_freq * t) + 0.1 * rng.standard_normal(n_times)
+    driven = np.roll(driver, 5) + 0.1 * rng.standard_normal(n_times)  # lagged copy
+    return np.stack([driver, driven])
+
+
+# ---------------------------------------------------------------------------
+# Feature discovery
+# ---------------------------------------------------------------------------
+
+
+def test_pdc_is_registered() -> None:
+    """PartialDirectedCoherence is auto-discovered by the feature module."""
+    assert hasattr(cb.feature, "PartialDirectedCoherence")
+
+
+# ---------------------------------------------------------------------------
+# Output structure
+# ---------------------------------------------------------------------------
+
+
+def test_pdc_output_dims() -> None:
+    """PDC returns Data with dims (space_to, space_from, frequency)."""
+    rng = np.random.default_rng(0)
+    data = _make_data(rng.standard_normal((4, 500)))
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    assert isinstance(out, cb.Data)
+    assert out.data.dims == ("space_to", "space_from", "frequency")
+
+
+def test_pdc_output_shape() -> None:
+    """PDC output shape is (n_ch, n_ch, n_freqs)."""
+    rng = np.random.default_rng(1)
+    n_ch, n_freqs = 3, 64
+    data = _make_data(rng.standard_normal((n_ch, 400)))
+    out = cb.feature.PartialDirectedCoherence(n_freqs=n_freqs).apply(data)
+
+    assert out.data.shape == (n_ch, n_ch, n_freqs)
+
+
+def test_pdc_space_coords_preserved() -> None:
+    """Space coordinates from the input are propagated to both space_to and space_from."""
+    labels = ["Fz", "Cz", "Pz"]
+    rng = np.random.default_rng(2)
+    data = _make_data(rng.standard_normal((3, 400)), space=labels)
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    np.testing.assert_array_equal(out.data.coords["space_to"].values, labels)
+    np.testing.assert_array_equal(out.data.coords["space_from"].values, labels)
+
+
+def test_pdc_frequency_coord_range() -> None:
+    """Frequency coordinates span [0, sr/2]."""
+    sr = 250.0
+    rng = np.random.default_rng(3)
+    data = _make_data(rng.standard_normal((2, 500)), sampling_rate=sr)
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    freqs = out.data.coords["frequency"].values
+    assert freqs[0] == pytest.approx(0.0)
+    assert freqs[-1] == pytest.approx(sr / 2.0)
+
+
+def test_pdc_returns_data_not_signal_data() -> None:
+    """output_type=Data: result is Data, not SignalData (no time dim)."""
+    rng = np.random.default_rng(4)
+    data = _make_data(rng.standard_normal((3, 300)))
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    assert type(out) is cb.Data
+    assert "time" not in out.data.dims
+
+
+def test_pdc_history_updated() -> None:
+    """apply() appends 'PartialDirectedCoherence' to history."""
+    rng = np.random.default_rng(5)
+    data = _make_data(rng.standard_normal((2, 300)))
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    assert out.history[-1] == "PartialDirectedCoherence"
+
+
+# ---------------------------------------------------------------------------
+# Numerical correctness
+# ---------------------------------------------------------------------------
+
+
+def test_pdc_values_in_unit_interval() -> None:
+    """All PDC values lie in [0, 1]."""
+    rng = np.random.default_rng(6)
+    data = _make_data(rng.standard_normal((4, 600)))
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    vals = out.data.values
+    assert np.all(vals >= 0.0 - 1e-10)
+    assert np.all(vals <= 1.0 + 1e-10)
+
+
+def test_pdc_column_sums_to_one() -> None:
+    """At each frequency, the squared PDC values sum to 1 over the sink dimension."""
+    rng = np.random.default_rng(7)
+    data = _make_data(rng.standard_normal((3, 600)))
+    out = cb.feature.PartialDirectedCoherence().apply(data)
+
+    # pdc[space_to, space_from, frequency]; sum over 'space_to' at each (space_from, freq) ≈ 1
+    vals = out.data.values  # (K, K, n_freqs)
+    col_sums_sq = (vals**2).sum(axis=0)  # (K, n_freqs)
+    np.testing.assert_allclose(col_sums_sq, 1.0, atol=1e-6)
+
+
+def test_pdc_directed_coupling_detected() -> None:
+    """PDC detects the direction of a planted coupling at the driving frequency."""
+    sr = 250.0
+    drive_freq = 40.0
+    arr = _coupled_signals(n_times=2000, sr=sr, drive_freq=drive_freq)
+    data = _make_data(arr, sampling_rate=sr)
+
+    out = cb.feature.PartialDirectedCoherence(var_order=5, n_freqs=256).apply(data)
+    freqs = out.data.coords["frequency"].values
+
+    # Find index closest to the drive frequency
+    f_idx = np.argmin(np.abs(freqs - drive_freq))
+    # channel 0 → channel 1: pdc[space_to=1, space_from=0, f]
+    pdc_01 = out.data.values[1, 0, f_idx]
+    # channel 1 → channel 0: pdc[space_to=0, space_from=1, f]
+    pdc_10 = out.data.values[0, 1, f_idx]
+
+    assert pdc_01 > pdc_10, (
+        f"Expected PDC(0→1)={pdc_01:.3f} > PDC(1→0)={pdc_10:.3f} at {drive_freq} Hz"
+    )
+
+
+def test_pdc_fixed_var_order() -> None:
+    """var_order parameter is respected (no crash, correct output dims)."""
+    rng = np.random.default_rng(8)
+    data = _make_data(rng.standard_normal((3, 400)))
+    out = cb.feature.PartialDirectedCoherence(var_order=3).apply(data)
+
+    assert out.data.dims == ("space_to", "space_from", "frequency")
+
+
+# ---------------------------------------------------------------------------
+# Validation / error paths
+# ---------------------------------------------------------------------------
+
+
+def test_pdc_requires_sampling_rate() -> None:
+    """Raises ValueError when data.sampling_rate is None."""
+    arr = xr.DataArray(np.random.default_rng(9).standard_normal((3, 200)), dims=["space", "time"])
+    data = cb.SignalData.from_xarray(arr, sampling_rate=None)
+
+    with pytest.raises(ValueError, match="sampling_rate"):
+        cb.feature.PartialDirectedCoherence().apply(data)
+
+
+def test_pdc_requires_at_least_2_channels() -> None:
+    """Raises ValueError for single-channel input."""
+    rng = np.random.default_rng(10)
+    data = _make_data(rng.standard_normal((1, 300)))
+
+    with pytest.raises(ValueError, match="2 channels"):
+        cb.feature.PartialDirectedCoherence().apply(data)
+
+
+def test_pdc_invalid_n_freqs_raises() -> None:
+    """n_freqs < 1 raises ValueError at construction."""
+    with pytest.raises(ValueError, match="n_freqs"):
+        cb.feature.PartialDirectedCoherence(n_freqs=0)
+
+
+def test_pdc_invalid_var_order_raises() -> None:
+    """var_order < 1 raises ValueError at construction."""
+    with pytest.raises(ValueError, match="var_order"):
+        cb.feature.PartialDirectedCoherence(var_order=0)

--- a/tests/test_feature_reciprocal_connectivity.py
+++ b/tests/test_feature_reciprocal_connectivity.py
@@ -1,0 +1,270 @@
+"""Tests for the ReciprocalConnectivity feature."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import cobrabox as cb
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_signal_data(
+    arr: np.ndarray, *, sampling_rate: float = 250.0, space: list[str] | None = None
+) -> cb.SignalData:
+    """Create SignalData from a (space, time) 2-D NumPy array."""
+    coords: dict = {}
+    if space is not None:
+        coords["space"] = space
+    xr_arr = xr.DataArray(arr, dims=["space", "time"], coords=coords)
+    return cb.SignalData.from_xarray(xr_arr, sampling_rate=sampling_rate)
+
+
+def _make_pdc_matrix(
+    vals: np.ndarray, *, space: list[str] | None = None, freqs: np.ndarray | None = None
+) -> cb.Data:
+    """Create a Data object from a pre-computed (space_to, space_from[, frequency]) matrix."""
+    n_ch = vals.shape[0]
+    space_vals = space if space is not None else list(range(n_ch))
+    coords: dict = {"space_to": space_vals, "space_from": space_vals}
+    if vals.ndim == 3 and freqs is not None:
+        coords["frequency"] = freqs
+        dims = ["space_to", "space_from", "frequency"]
+    else:
+        dims = ["space_to", "space_from"]
+    xr_arr = xr.DataArray(vals, dims=dims, coords=coords)
+    return cb.Data.from_xarray(xr_arr)
+
+
+def _coupled_signals(n_times: int, sr: float, drive_freq: float = 40.0) -> np.ndarray:
+    """Return (2, n_times) where channel 0 drives channel 1."""
+    rng = np.random.default_rng(42)
+    t = np.arange(n_times) / sr
+    driver = np.sin(2 * np.pi * drive_freq * t) + 0.1 * rng.standard_normal(n_times)
+    driven = np.roll(driver, 5) + 0.1 * rng.standard_normal(n_times)
+    return np.stack([driver, driven])
+
+
+# ---------------------------------------------------------------------------
+# Feature discovery
+# ---------------------------------------------------------------------------
+
+
+def test_rc_is_registered() -> None:
+    """ReciprocalConnectivity is auto-discovered by the feature module."""
+    assert hasattr(cb.feature, "ReciprocalConnectivity")
+
+
+# ---------------------------------------------------------------------------
+# Output structure — time-series path
+# ---------------------------------------------------------------------------
+
+
+def test_rc_from_timeseries_output_dims() -> None:
+    """From time-series: output has dim ('space',) only."""
+    rng = np.random.default_rng(0)
+    data = _make_signal_data(rng.standard_normal((3, 800)))
+    out = cb.feature.ReciprocalConnectivity(freq_band=(10.0, 60.0)).apply(data)
+
+    assert isinstance(out, cb.Data)
+    assert out.data.dims == ("space",)
+
+
+def test_rc_from_timeseries_output_shape() -> None:
+    """Output vector length equals number of channels."""
+    rng = np.random.default_rng(1)
+    n_ch = 4
+    data = _make_signal_data(rng.standard_normal((n_ch, 800)))
+    out = cb.feature.ReciprocalConnectivity(freq_band=(10.0, 60.0)).apply(data)
+
+    assert out.data.shape == (n_ch,)
+
+
+def test_rc_from_timeseries_space_coords_preserved() -> None:
+    """Space coordinates are carried through to the output."""
+    labels = ["Fz", "Cz", "Pz"]
+    rng = np.random.default_rng(2)
+    data = _make_signal_data(rng.standard_normal((3, 800)), space=labels)
+    out = cb.feature.ReciprocalConnectivity(freq_band=(10.0, 60.0)).apply(data)
+
+    np.testing.assert_array_equal(out.data.coords["space"].values, labels)
+
+
+def test_rc_history_updated() -> None:
+    """apply() appends 'ReciprocalConnectivity' to history."""
+    rng = np.random.default_rng(3)
+    data = _make_signal_data(rng.standard_normal((2, 800)))
+    out = cb.feature.ReciprocalConnectivity(freq_band=(10.0, 60.0)).apply(data)
+
+    assert out.history[-1] == "ReciprocalConnectivity"
+
+
+# ---------------------------------------------------------------------------
+# Numerical correctness — time-series path
+# ---------------------------------------------------------------------------
+
+
+def test_rc_driver_is_negative_sink_is_positive() -> None:
+    """Known driver (ch 0) has negative RC; known sink (ch 1) has positive RC."""
+    sr = 250.0
+    arr = _coupled_signals(n_times=3000, sr=sr, drive_freq=40.0)
+    data = _make_signal_data(arr, sampling_rate=sr)
+
+    out = cb.feature.ReciprocalConnectivity(freq_band=(30.0, 55.0), var_order=5).apply(data)
+    rc = out.data.values  # (2,)
+
+    assert rc[0] < 0, f"Driver ch0 expected negative RC, got {rc[0]:.4f}"
+    assert rc[1] > 0, f"Sink  ch1 expected positive RC, got {rc[1]:.4f}"
+
+
+def test_rc_normalize_changes_values_not_shape() -> None:
+    """normalize=True produces different values but same shape."""
+    # Use coupled signals so RC values are nonzero (not near 0 for all channels)
+    arr = _coupled_signals(n_times=3000, sr=250.0, drive_freq=40.0)
+    data = _make_signal_data(arr, sampling_rate=250.0)
+
+    out_raw = cb.feature.ReciprocalConnectivity(
+        freq_band=(30.0, 55.0), var_order=5, normalize=False
+    ).apply(data)
+    out_norm = cb.feature.ReciprocalConnectivity(
+        freq_band=(30.0, 55.0), var_order=5, normalize=True
+    ).apply(data)
+
+    assert out_raw.data.shape == out_norm.data.shape
+    assert not np.allclose(out_raw.data.values, out_norm.data.values)
+
+
+# ---------------------------------------------------------------------------
+# Pre-computed matrix path
+# ---------------------------------------------------------------------------
+
+
+def test_rc_from_precomputed_2d_matrix() -> None:
+    """From a pre-computed asymmetric 2-D matrix (no freq dim)."""
+    # mat[i, j] = flow from j → i  (space_to=i, space_from=j)
+    # mat[0, 1] = 0.3: flow from ch1 → ch0
+    # mat[1, 0] = 0.7: flow from ch0 → ch1
+    # ch0: in=0.3, out=0.7 → RC = -0.4  (net source)
+    # ch1: in=0.7, out=0.3 → RC = +0.4  (net sink)
+    mat = np.array([[0.0, 0.3], [0.7, 0.0]])
+    data = _make_pdc_matrix(mat)
+
+    out = cb.feature.ReciprocalConnectivity(freq_band=None).apply(data)
+
+    assert out.data.dims == ("space",)
+    assert out.data.shape == (2,)
+    np.testing.assert_allclose(out.data.values, [-0.4, 0.4], atol=1e-10)
+    assert out.data.values[0] < 0, "ch0 sends more than it receives → should be negative"
+    assert out.data.values[1] > 0, "ch1 receives more than it sends → should be positive"
+
+
+def test_rc_from_precomputed_3d_matrix_with_freq_band() -> None:
+    """From a pre-computed 3-D matrix with frequency averaging."""
+    n_ch, n_freqs = 3, 64
+    rng = np.random.default_rng(5)
+    mat = rng.random((n_ch, n_ch, n_freqs))
+    # Make it asymmetric by zeroing upper triangle
+    for k in range(n_freqs):
+        np.fill_diagonal(mat[:, :, k], 0.0)
+    mat[0, 1, :] = 0.9  # strong flow from ch1 to ch0
+    freqs = np.linspace(0.0, 125.0, n_freqs)
+    data = _make_pdc_matrix(mat, freqs=freqs)
+
+    out = cb.feature.ReciprocalConnectivity(freq_band=(30.0, 80.0)).apply(data)
+
+    assert out.data.dims == ("space",)
+    assert out.data.shape == (n_ch,)
+
+
+def test_rc_precomputed_space_coords_preserved() -> None:
+    """Space coords on pre-computed 2-D matrix are propagated to output."""
+    labels = ["A", "B", "C"]
+    rng = np.random.default_rng(6)
+    mat = rng.random((3, 3))
+    np.fill_diagonal(mat, 0.0)
+    # Ensure it is asymmetric
+    mat[0, 1] = 0.9
+    mat[1, 0] = 0.1
+    data = _make_pdc_matrix(mat, space=labels)
+
+    out = cb.feature.ReciprocalConnectivity(freq_band=None).apply(data)
+
+    np.testing.assert_array_equal(out.data.coords["space"].values, labels)
+
+
+# ---------------------------------------------------------------------------
+# Validation / error paths
+# ---------------------------------------------------------------------------
+
+
+def test_rc_unsupported_connectivity_raises() -> None:
+    """Unsupported connectivity measure raises ValueError for time-series input."""
+    rng = np.random.default_rng(7)
+    data = _make_signal_data(rng.standard_normal((2, 500)))
+
+    with pytest.raises(ValueError, match="'dtf'"):
+        cb.feature.ReciprocalConnectivity(connectivity="dtf", freq_band=(10.0, 60.0)).apply(data)
+
+
+def test_rc_symmetric_matrix_raises() -> None:
+    """A symmetric pre-computed matrix raises ValueError."""
+    mat = np.array([[0.0, 0.5], [0.5, 0.0]])
+    data = _make_pdc_matrix(mat)
+
+    with pytest.raises(ValueError, match="symmetric"):
+        cb.feature.ReciprocalConnectivity(freq_band=None).apply(data)
+
+
+def test_rc_freq_band_set_but_no_freq_dim_raises() -> None:
+    """Setting freq_band on a matrix without frequency dim raises ValueError."""
+    mat = np.array([[0.0, 0.7], [0.3, 0.0]])
+    data = _make_pdc_matrix(mat)
+
+    with pytest.raises(ValueError, match="freq_band"):
+        cb.feature.ReciprocalConnectivity(freq_band=(30.0, 80.0)).apply(data)
+
+
+def test_rc_freq_band_outside_range_raises() -> None:
+    """freq_band outside the available frequency range raises ValueError."""
+    n_ch, n_freqs = 2, 64
+    rng = np.random.default_rng(8)
+    mat = rng.random((n_ch, n_ch, n_freqs))
+    mat[0, 1, :] = 0.9  # asymmetric
+    freqs = np.linspace(0.0, 60.0, n_freqs)  # max freq = 60 Hz
+    data = _make_pdc_matrix(mat, freqs=freqs)
+
+    with pytest.raises(ValueError, match="outside the available"):
+        cb.feature.ReciprocalConnectivity(freq_band=(70.0, 100.0)).apply(data)
+
+
+def test_rc_freq_band_none_but_freq_dim_present_raises() -> None:
+    """freq_band=None with a frequency dimension raises ValueError."""
+    n_ch, n_freqs = 2, 64
+    rng = np.random.default_rng(9)
+    mat = rng.random((n_ch, n_ch, n_freqs))
+    mat[0, 1, :] = 0.9
+    freqs = np.linspace(0.0, 125.0, n_freqs)
+    data = _make_pdc_matrix(mat, freqs=freqs)
+
+    with pytest.raises(ValueError, match=r"frequency.*dimension"):
+        cb.feature.ReciprocalConnectivity(freq_band=None).apply(data)
+
+
+def test_rc_invalid_freq_band_fmin_ge_fmax_raises() -> None:
+    """freq_band where fmin >= fmax raises ValueError at construction."""
+    with pytest.raises(ValueError, match="fmin < fmax"):
+        cb.feature.ReciprocalConnectivity(freq_band=(80.0, 30.0))
+
+
+def test_rc_precomputed_missing_space_dims_raises() -> None:
+    """Pre-computed matrix without expected dims raises ValueError."""
+    # A Data object with only a 'space' dim (not 'space_to'/'space_from') — no 'time' either
+    xr_arr = xr.DataArray(np.array([0.1, 0.2, 0.3]), dims=["space"])
+    data = cb.Data.from_xarray(xr_arr)
+
+    with pytest.raises(ValueError, match="'space_from'"):
+        cb.feature.ReciprocalConnectivity(freq_band=None).apply(data)

--- a/uv.lock
+++ b/uv.lock
@@ -324,6 +324,7 @@ dependencies = [
     { name = "pandas" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "statsmodels" },
     { name = "xarray" },
 ]
 
@@ -348,6 +349,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=3.0.1" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "scipy", specifier = ">=1.17.1" },
+    { name = "statsmodels", specifier = ">=0.14" },
     { name = "xarray", specifier = ">=2026.2.0" },
 ]
 
@@ -1736,6 +1738,18 @@ wheels = [
 ]
 
 [[package]]
+name = "patsy"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/44/ed13eccdd0519eff265f44b670d46fbb0ec813e2274932dc1c0e48520f7d/patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0", size = 399942, upload-time = "2025-10-20T16:17:37.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a", size = 233301, upload-time = "2025-10-20T16:17:36.563Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2473,6 +2487,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/81/e8d74b34f85285f7335d30c5e3c2d7c0346997af9f3debf9a0a9a63de184/statsmodels-0.14.6.tar.gz", hash = "sha256:4d17873d3e607d398b85126cd4ed7aad89e4e9d89fc744cdab1af3189a996c2a", size = 20689085, upload-time = "2025-12-05T23:08:39.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/4d/df4dd089b406accfc3bb5ee53ba29bb3bdf5ae61643f86f8f604baa57656/statsmodels-0.14.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ad5c2810fc6c684254a7792bf1cbaf1606cdee2a253f8bd259c43135d87cfb4", size = 10121514, upload-time = "2025-12-05T19:28:16.521Z" },
+    { url = "https://files.pythonhosted.org/packages/82/af/ec48daa7f861f993b91a0dcc791d66e1cf56510a235c5cbd2ab991a31d5c/statsmodels-0.14.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:341fa68a7403e10a95c7b6e41134b0da3a7b835ecff1eb266294408535a06eb6", size = 10003346, upload-time = "2025-12-05T19:28:29.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/2c/c8f7aa24cd729970728f3f98822fb45149adc216f445a9301e441f7ac760/statsmodels-0.14.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bdf1dfe2a3ca56f5529118baf33a13efed2783c528f4a36409b46bbd2d9d48eb", size = 10129872, upload-time = "2025-12-05T23:09:25.724Z" },
+    { url = "https://files.pythonhosted.org/packages/40/c6/9ae8e9b0721e9b6eb5f340c3a0ce8cd7cce4f66e03dd81f80d60f111987f/statsmodels-0.14.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3764ba8195c9baf0925a96da0743ff218067a269f01d155ca3558deed2658ca", size = 10381964, upload-time = "2025-12-05T23:09:41.326Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8c/cf3d30c8c2da78e2ad1f50ade8b7fabec3ff4cdfc56fbc02e097c4577f90/statsmodels-0.14.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9e8d2e519852adb1b420e018f5ac6e6684b2b877478adf7fda2cfdb58f5acb5d", size = 10409611, upload-time = "2025-12-05T23:09:57.131Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/cc/018f14ecb58c6cb89de9d52695740b7d1f5a982aa9ea312483ea3c3d5f77/statsmodels-0.14.6-cp311-cp311-win_amd64.whl", hash = "sha256:2738a00fca51196f5a7d44b06970ace6b8b30289839e4808d656f8a98e35faa7", size = 9580385, upload-time = "2025-12-05T19:28:42.778Z" },
+    { url = "https://files.pythonhosted.org/packages/25/ce/308e5e5da57515dd7cab3ec37ea2d5b8ff50bef1fcc8e6d31456f9fae08e/statsmodels-0.14.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5", size = 10091932, upload-time = "2025-12-05T19:28:55.446Z" },
+    { url = "https://files.pythonhosted.org/packages/05/30/affbabf3c27fb501ec7b5808230c619d4d1a4525c07301074eb4bda92fa9/statsmodels-0.14.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26d4f0ed3b31f3c86f83a92f5c1f5cbe63fc992cd8915daf28ca49be14463a1c", size = 9997345, upload-time = "2025-12-05T19:29:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f5/3a73b51e6450c31652c53a8e12e24eac64e3824be816c0c2316e7dbdcb7d/statsmodels-0.14.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8c00a42863e4f4733ac9d078bbfad816249c01451740e6f5053ecc7db6d6368", size = 10058649, upload-time = "2025-12-05T23:10:12.775Z" },
+    { url = "https://files.pythonhosted.org/packages/81/68/dddd76117df2ef14c943c6bbb6618be5c9401280046f4ddfc9fb4596a1b8/statsmodels-0.14.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b58cf7474aa9e7e3b0771a66537148b2df9b5884fbf156096c0e6c1ff0469d", size = 10339446, upload-time = "2025-12-05T23:10:28.503Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4a/dce451c74c4050535fac1ec0c14b80706d8fc134c9da22db3c8a0ec62c33/statsmodels-0.14.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e7dcc5e9587f2567e52deaff5220b175bf2f648951549eae5fc9383b62bc37", size = 10368705, upload-time = "2025-12-05T23:10:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/60/15/3daba2df40be8b8a9a027d7f54c8dedf24f0d81b96e54b52293f5f7e3418/statsmodels-0.14.6-cp312-cp312-win_amd64.whl", hash = "sha256:b5eb07acd115aa6208b4058211138393a7e6c2cf12b6f213ede10f658f6a714f", size = 9543991, upload-time = "2025-12-05T23:10:58.536Z" },
+    { url = "https://files.pythonhosted.org/packages/81/59/a5aad5b0cc266f5be013db8cde563ac5d2a025e7efc0c328d83b50c72992/statsmodels-0.14.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47ee7af083623d2091954fa71c7549b8443168f41b7c5dce66510274c50fd73e", size = 10072009, upload-time = "2025-12-05T23:11:14.021Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dd/d8cfa7922fc6dc3c56fa6c59b348ea7de829a94cd73208c6f8202dd33f17/statsmodels-0.14.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa60d82e29fcd0a736e86feb63a11d2380322d77a9369a54be8b0965a3985f71", size = 9980018, upload-time = "2025-12-05T23:11:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/77/0ec96803eba444efd75dba32f2ef88765ae3e8f567d276805391ec2c98c6/statsmodels-0.14.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89ee7d595f5939cc20bf946faedcb5137d975f03ae080f300ebb4398f16a5bd4", size = 10060269, upload-time = "2025-12-05T23:11:46.338Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b9/fd41f1f6af13a1a1212a06bb377b17762feaa6d656947bf666f76300fc05/statsmodels-0.14.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:730f3297b26749b216a06e4327fe0be59b8d05f7d594fb6caff4287b69654589", size = 10324155, upload-time = "2025-12-05T23:12:01.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0f/a6900e220abd2c69cd0a07e3ad26c71984be6061415a60e0f17b152ecf08/statsmodels-0.14.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1c08befa85e93acc992b72a390ddb7bd876190f1360e61d10cf43833463bc9c", size = 10349765, upload-time = "2025-12-05T23:12:18.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/08/b79f0c614f38e566eebbdcff90c0bcacf3c6ba7a5bbb12183c09c29ca400/statsmodels-0.14.6-cp313-cp313-win_amd64.whl", hash = "sha256:8021271a79f35b842c02a1794465a651a9d06ec2080f76ebc3b7adce77d08233", size = 9540043, upload-time = "2025-12-05T23:12:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/71/de/09540e870318e0c7b58316561d417be45eff731263b4234fdd2eee3511a8/statsmodels-0.14.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:00781869991f8f02ad3610da6627fd26ebe262210287beb59761982a8fa88cae", size = 10069403, upload-time = "2025-12-05T23:12:48.424Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f0/63c1bfda75dc53cee858006e1f46bd6d6f883853bea1b97949d0087766ca/statsmodels-0.14.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:73f305fbf31607b35ce919fae636ab8b80d175328ed38fdc6f354e813b86ee37", size = 9989253, upload-time = "2025-12-05T23:13:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/98/b0dfb4f542b2033a3341aa5f1bdd97024230a4ad3670c5b0839d54e3dcab/statsmodels-0.14.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e443e7077a6e2d3faeea72f5a92c9f12c63722686eb80bb40a0f04e4a7e267ad", size = 10090802, upload-time = "2025-12-05T23:13:20.653Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
+    { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
…vity; add EEG(SignalData) with ref_channel validation ('average', 'bipolar', or space coord), add PartialDirectedCoherence as VAR-based PDC spectrum with dims (space_to, space_from, frequency), values in [0,1] with column normalisation and statsmodels>=0.14 added as dependency, add ReciprocalConnectivity for per-channel RC = in_strength - out_strength from PDC or pre-computed matrix where positive = net sink and negative = net source, standardise pairwise connectivity dim names across all features so dim0 is space_to (destination) and dim1 is space_from (source), affecting Coherence and EnvelopeCorrelation