### PR TITLE
Add Fourier Transformed surrogates splitter feature.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+    "ipython>=9.10.0",
     "mne-connectivity>=0.7.0",
     "numpy>=2.4.2",
     "pandas>=3.0.1",

--- a/src/cobrabox/feature.pyi
+++ b/src/cobrabox/feature.pyi
@@ -11,6 +11,7 @@ from .features import DiscreteWaveletTransform as DiscreteWaveletTransform
 from .features import Dummy as Dummy
 from .features import EnvelopeCorrelation as EnvelopeCorrelation
 from .features import EpileptogenicityIndex as EpileptogenicityIndex
+from .features import FourierTransformSurrogates as FourierTransformSurrogates
 from .features import FractalDimHiguchi as FractalDimHiguchi
 from .features import FractalDimKatz as FractalDimKatz
 from .features import GrangerCausality as GrangerCausality
@@ -47,6 +48,7 @@ __all__ = [
     "Dummy",
     "EnvelopeCorrelation",
     "EpileptogenicityIndex",
+    "FourierTransformSurrogates",
     "FractalDimHiguchi",
     "FractalDimKatz",
     "GrangerCausality",

--- a/src/cobrabox/features/__init__.pyi
+++ b/src/cobrabox/features/__init__.pyi
@@ -9,6 +9,7 @@ from .coherence import Coherence as Coherence
 from .dummy import Dummy as Dummy
 from .envelope_correlation import EnvelopeCorrelation as EnvelopeCorrelation
 from .epileptogenicity_index import EpileptogenicityIndex as EpileptogenicityIndex
+from .fourier_transform_surrogates import FourierTransformSurrogates as FourierTransformSurrogates
 from .fractal_dimension import FractalDimHiguchi as FractalDimHiguchi
 from .fractal_dimension import FractalDimKatz as FractalDimKatz
 from .granger_causality import GrangerCausality as GrangerCausality
@@ -47,6 +48,7 @@ __all__ = [
     "Dummy",
     "EnvelopeCorrelation",
     "EpileptogenicityIndex",
+    "FourierTransformSurrogates",
     "FractalDimHiguchi",
     "FractalDimKatz",
     "GrangerCausality",

--- a/src/cobrabox/features/fourier_transform_surrogates.py
+++ b/src/cobrabox/features/fourier_transform_surrogates.py
@@ -1,0 +1,60 @@
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..base_feature import SplitterFeature
+from ..data import SignalData
+
+
+@dataclass
+class FourierTransformSurrogates(SplitterFeature[SignalData]):
+    """Generate Fourier transform (i.e., preserving autocorrelation) of SignalData (surrogates
+    the time axis).
+
+    Parameters:
+    ---------
+        n_surrogates: int
+        multivariate: bool = True
+            If True (default) applies the same random phases to all the series. This ensures that
+            also correlation is (approximately) preserved. This applies across all dimensions.
+        return_data: bool = True
+            If True (default) the generator has length 1+n_surrogates where the first element is
+            the original data such that it can follow the same pipeline as the surrogates.
+        random_state: np.random.Generator | int | None = None
+            Initialiser for the pseudorandom number generator to ensure reproducibility.
+
+    Output:
+    ----------
+    SignalData iterator containing the surrogate time series.
+    """
+
+    n_surrogates: int
+    multivariate: bool = True
+    return_data: bool = True
+    random_state: np.random.Generator | int | None = None
+
+    def __post_init__(self) -> None:
+        assert isinstance(self.n_surrogates, int), "The number of surrogates must be an integer."
+        assert self.n_surrogates >= 0, "The number of surrogates cannot be negative."
+
+    def _surrogate(self, data: SignalData) -> SignalData:
+        rng = np.random.default_rng(self.random_state)
+        data.data.transpose(..., "time")
+        tmp = np.reshape(data.data.data, [-1, data.data.shape[-1]])
+        fft = np.fft.rfft(tmp, axis=1)
+        extra_shape = 1 if self.multivariate else tmp.shape[0]
+
+        rpha = np.exp(2 * np.pi * rng.random([extra_shape, int(tmp.shape[1] / 2 + 1)]) * 1.0j)
+        fftX1 = fft * rpha
+
+        xs = np.reshape(np.fft.irfft(fftX1, n=tmp.shape[1], axis=1), data.data.shape)
+
+        return SignalData.from_numpy(xs, dims=list(data.data.dims))
+
+    def __call__(self, data: SignalData) -> Iterator[SignalData]:
+
+        if self.return_data:
+            yield data
+        for _ in range(self.n_surrogates):
+            yield self._surrogate(data)

--- a/tests/test_feature_fourier_transform_surrogates.py
+++ b/tests/test_feature_fourier_transform_surrogates.py
@@ -1,0 +1,120 @@
+"""Tests for the FourierTransformSurrogates splitter feature."""
+
+from __future__ import annotations
+
+import numpy as np
+
+import cobrabox as cb
+from cobrabox.features.fourier_transform_surrogates import FourierTransformSurrogates
+
+
+def test_surrogate_shape_and_dims_preserved_2D(rng: np.random.Generator) -> None:
+    # create a simple time x space signal
+    arr = rng.standard_normal((50, 2))
+    data = cb.SignalData.from_numpy(arr, dims=["time", "space"], sampling_rate=100.0)
+
+    feat = FourierTransformSurrogates(n_surrogates=1, random_state=42, return_data=False)
+    out = next(feat(data))
+
+    assert isinstance(out, cb.SignalData)
+    assert out.data.shape == data.data.shape
+    assert out.data.dims == data.data.dims
+    # surrogates should differ from the original
+    assert not np.allclose(out.to_numpy(), data.to_numpy())
+
+
+def test_surrogate_shape_and_dims_preserved_4D(rng: np.random.Generator) -> None:
+    # create a multi-dimensional time x space x ... signal
+    arr = rng.standard_normal((50, 2, 3, 4))
+    data = cb.SignalData.from_numpy(arr, dims=["time", "chan", "x", "y"], sampling_rate=100.0)
+
+    feat = FourierTransformSurrogates(n_surrogates=1, random_state=42, return_data=False)
+    out = next(feat(data))
+
+    assert isinstance(out, cb.SignalData)
+    assert out.data.shape == data.data.shape
+    assert out.data.dims == data.data.dims
+    # surrogates should differ from the original
+    assert not np.allclose(out.to_numpy(), data.to_numpy())
+
+
+def test_return_data_flag_controls_original_yield(rng: np.random.Generator) -> None:
+    arr = rng.standard_normal((10, 3))
+    data = cb.SignalData.from_numpy(arr, dims=["time", "space"])
+
+    feat_true = FourierTransformSurrogates(n_surrogates=2, return_data=True, random_state=0)
+    seq_true = list(feat_true(data))
+    assert len(seq_true) == 3  # original + 2 surrogates
+    assert np.array_equal(seq_true[0].to_numpy(), data.to_numpy())
+
+    feat_false = FourierTransformSurrogates(n_surrogates=2, return_data=False, random_state=0)
+    seq_false = list(feat_false(data))
+    assert len(seq_false) == 2
+    assert not np.array_equal(seq_false[0].to_numpy(), data.to_numpy())
+
+
+def test_n_surrogates_zero_behaviour(rng: np.random.Generator) -> None:
+    arr = rng.standard_normal((5, 1))
+    data = cb.SignalData.from_numpy(arr, dims=["time", "space"])
+
+    feat = FourierTransformSurrogates(n_surrogates=0, return_data=True)
+    assert list(feat(data)) == [data]
+
+    feat2 = FourierTransformSurrogates(n_surrogates=0, return_data=False)
+    assert list(feat2(data)) == []
+
+
+def test_random_state_reproducibility(rng: np.random.Generator) -> None:
+    arr = rng.standard_normal((20, 4))
+    data = cb.SignalData.from_numpy(arr, dims=["time", "space"])
+
+    feat = FourierTransformSurrogates(n_surrogates=1, random_state=123, return_data=False)
+    first = next(feat(data)).to_numpy()
+    second = next(feat(data)).to_numpy()  # same seed, should reproduce
+    assert np.array_equal(first, second)
+
+
+def test_multivariate_flag_changes_channel_relations(rng: np.random.Generator) -> None:
+    r = 0.6
+    D = 6
+    L = 10000
+    S = np.ones([D, D]) * r
+    S[np.diag_indices(D)] = 1
+    arr = rng.multivariate_normal(np.zeros(D), S, size=L).T
+    data = cb.SignalData.from_numpy(arr, dims=["space", "time"])
+    data_corr = np.corrcoef(arr)
+    data_rho = np.mean(data_corr[np.triu_indices(D, 1)])
+    feat_multi = FourierTransformSurrogates(
+        n_surrogates=1, random_state=0, multivariate=True, return_data=False
+    )
+    out_multi = next(feat_multi(data)).to_numpy()
+    multi_corr = np.corrcoef(out_multi)
+    multi_rho = np.mean(multi_corr[np.triu_indices(D, 1)])
+    # the correlation should be similar when multivariate=True
+    assert np.abs(multi_rho - data_rho) / data_rho < 0.05
+
+    feat_ind = FourierTransformSurrogates(
+        n_surrogates=1, random_state=0, multivariate=False, return_data=False
+    )
+    out_ind = next(feat_ind(data)).to_numpy()
+    ind_corr = np.corrcoef(out_ind)
+    ind_rho = np.mean(ind_corr[np.triu_indices(D, 1)])
+    # the correlation should be close to zero when multivariate=False
+    assert np.abs(ind_rho) < 0.05
+
+
+def test_identical_channels_remain_identical_multivariate(rng: np.random.Generator) -> None:
+    # Create data with identical channels
+    arr = rng.standard_normal((100, 3))
+    arr[:, 1] = arr[:, 0]  # Make second channel identical to first
+    data = cb.SignalData.from_numpy(arr, dims=["time", "space"])
+
+    feat = FourierTransformSurrogates(
+        n_surrogates=1, random_state=42, multivariate=True, return_data=False
+    )
+    out = next(feat(data)).to_numpy()
+
+    # Identical channels should remain identical after surrogating
+    assert np.allclose(out[0, :], out[1, :])
+    # Non-identical channels should differ
+    assert not np.allclose(out[0, :], out[2, :])

--- a/uv.lock
+++ b/uv.lock
@@ -7,12 +7,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version < '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
@@ -319,6 +319,8 @@ name = "cobrabox"
 version = "0.2.10"
 source = { editable = "." }
 dependencies = [
+    { name = "ipython", version = "9.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "ipython", version = "9.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "mne-connectivity" },
     { name = "numpy" },
     { name = "pandas" },
@@ -345,6 +347,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "ipython", specifier = ">=9.10.0" },
     { name = "mne-connectivity", specifier = ">=0.7.0" },
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "pandas", specifier = ">=3.0.1" },
@@ -1756,7 +1759,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
This implements the basic version enabling conserved correlation and autocorrelation without (iterative) amplitude adjustment.