### PR TITLE
Fix partial cache visibility and add Swiss EEG size estimates

### DIFF
--- a/src/cobrabox/datasets.py
+++ b/src/cobrabox/datasets.py
@@ -453,7 +453,7 @@ def dataset_info(identifier: str) -> DatasetInfo:
             info_url=spec.info_url,
             license=spec.license,
             auth_hint=spec.auth_hint,
-            local_path=cached_path if _dataset_cache_status(spec) == "yes" else None,
+            local_path=cached_path if _dataset_cache_status(spec) != "no" else None,
         )
 
     raise ValueError(

--- a/src/cobrabox/downloader.py
+++ b/src/cobrabox/downloader.py
@@ -748,6 +748,7 @@ def _swiss_eeg_short_spec() -> RemoteDatasetSpec:
         known_subset_keys=tuple(_SWISS_EEG_SHORT_IDS),
         size_hint="~11 GB",
         subset_size_hint="~100 MB - 1 GB per subject",
+        subset_size_bytes=(600 * 1024**2),  # ~600 MB average (~11 GB / 18 subjects)
         # Per-subject counts are in Burrello et al. TBME 2019 (doi:10.1109/TBME.2019.2921940)
         # but the paper PDF is not publicly accessible as plain text.
         seizure_info_url="https://iis-people.ee.ethz.ch/~ieeg/BioCAS2018/",
@@ -783,6 +784,7 @@ def _swiss_eeg_long_spec() -> RemoteDatasetSpec:
         known_subset_keys=_SWEZ_LONG_SUBJECTS,
         size_hint=">1 TB (hundreds of hourly files per subject)",
         subset_size_hint="~100-200 GB per subject (~619 MB per hourly file)",
+        subset_size_bytes=(150 * 1024**3),  # ~150 GB midpoint of 100-200 GB range
         # 116 seizures total across 18 subjects (Burrello et al., DATE 2019).
         # Per-subject breakdown is in the Laelaps paper, but the SWEZ website
         # (seizure_info_url) has TLS issues preventing automated access.


### PR DESCRIPTION
## Summary

- **Show `local_path` for partial caches** — `dataset_info()` previously only set `local_path` when a dataset was fully downloaded (`"yes"`). Now it also shows the path for partially cached datasets (`"3/18"` etc.), so users can find their data even when only a subset has been downloaded.
- **Add `subset_size_bytes` for Swiss EEG short and long** — these were the only two datasets missing computed size estimates. The download prompt will now show a calculated size when a subject subset is requested (~600 MB avg per subject for short, ~150 GB midpoint for long).

## Test plan

- [x] All 979 tests pass
- [x] `ruff check` and `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)